### PR TITLE
Feat/admin anotation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,70 +1,8 @@
-# Diretórios de build e publicação
 **/bin/
 **/obj/
-**/out/
-**/dist/
-**/build/
-
-# Configurações de desenvolvimento
 **/.vscode/
-**/.idea/
-**/.vs/
-
-# Diretórios de dependências
+**/.git/
 **/node_modules/
-**/packages/
-
-# Arquivos de configuração de ambiente e segurança
-*.user
-*.suo
-*.launchSettings.json
-*.ps1
-*.sh
-*.cmd
-
-# Diretórios e arquivos do sistema operacional
-.DS_Store
-Thumbs.db
-
-# Diretórios de controle de versão
-.git/
-.gitignore
-.gitattributes
-
-# Docker e CI/CD
-.dockerignore
+**/.idea/
+Dockerfile
 docker-compose.yml
-docker-compose.override.yml
-
-# Logs
-*.log
-
-# Arquivos temporários e de cache
-*.tmp
-*.temp
-*.bak
-*.old
-*.swp
-*~ 
-
-# Arquivos e diretórios específicos de ambiente
-.env
-.env.local
-.env.*.local
-.env.development.local
-.env.test.local
-.env.production.local
-
-# Outros arquivos desnecessários
-*.md
-*.yml
-*.yaml
-*.txt
-*.config
-*.json
-
-# Certificados SSL/TLS (se aplicável)
-*.pfx
-*.p12
-*.cer
-*.crt

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,70 @@
+# Diretórios de build e publicação
 **/bin/
 **/obj/
+**/out/
+**/dist/
+**/build/
+
+# Configurações de desenvolvimento
 **/.vscode/
-**/.git/
-Dockerfile
+**/.idea/
+**/.vs/
+
+# Diretórios de dependências
+**/node_modules/
+**/packages/
+
+# Arquivos de configuração de ambiente e segurança
+*.user
+*.suo
+*.launchSettings.json
+*.ps1
+*.sh
+*.cmd
+
+# Diretórios e arquivos do sistema operacional
+.DS_Store
+Thumbs.db
+
+# Diretórios de controle de versão
+.git/
+.gitignore
+.gitattributes
+
+# Docker e CI/CD
+.dockerignore
 docker-compose.yml
+docker-compose.override.yml
+
+# Logs
+*.log
+
+# Arquivos temporários e de cache
+*.tmp
+*.temp
+*.bak
+*.old
+*.swp
+*~ 
+
+# Arquivos e diretórios específicos de ambiente
+.env
+.env.local
+.env.*.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Outros arquivos desnecessários
+*.md
+*.yml
+*.yaml
+*.txt
+*.config
+*.json
+
+# Certificados SSL/TLS (se aplicável)
+*.pfx
+*.p12
+*.cer
+*.crt

--- a/Bindings/AdminModelBinder.cs
+++ b/Bindings/AdminModelBinder.cs
@@ -1,0 +1,49 @@
+﻿using DevJobsBackend.Contracts.Services;
+using DevJobsBackend.Entities;
+using DevJobsBackend.Enums;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public class AdminModelBinder : IModelBinder
+{
+    private readonly IAuthService _authService;
+
+    public AdminModelBinder(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var httpContext = bindingContext.HttpContext;
+        var authorizationHeader = httpContext.Request.Headers["Authorization"].FirstOrDefault();
+
+        if (string.IsNullOrEmpty(authorizationHeader) || !authorizationHeader.StartsWith("Bearer "))
+        {
+            bindingContext.Result = ModelBindingResult.Failed();
+            return;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+        try
+        {
+            var user = await _authService.GetUserByAccessToken(token);
+
+            if (user != null && user.TypeUser == UserType.ADMIN)
+            {
+                bindingContext.Result = ModelBindingResult.Success(user);
+            }
+            else
+            {
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+        }
+        catch
+        {
+            bindingContext.Result = ModelBindingResult.Failed();
+        }
+    }
+}

--- a/Bindings/AdminModelBinderProvider.cs
+++ b/Bindings/AdminModelBinderProvider.cs
@@ -1,0 +1,25 @@
+﻿using DevJobsBackend.Contracts.Services;
+using DevJobsBackend.Entities;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.DependencyInjection;
+
+public class AdminModelBinderProvider : IModelBinderProvider
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public AdminModelBinderProvider(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public IModelBinder GetBinder(ModelBinderProviderContext context)
+    {
+        if (context.Metadata.ModelType == typeof(User))
+        {
+            return new BinderTypeModelBinder(typeof(AdminModelBinder));
+        }
+
+        return null;
+    }
+}

--- a/Controllers/EmailController.cs
+++ b/Controllers/EmailController.cs
@@ -19,6 +19,7 @@ namespace DevJobsBackend.Controllers
         }
 
         [HttpGet]
+        [Admin]
         public async Task<ResponseBase<IEnumerable<EmailTemplate>>> GetAllTemplates()
         {
             return await _emailService.GetAllTemplatesAsync();
@@ -31,12 +32,16 @@ namespace DevJobsBackend.Controllers
         }
 
         [HttpPost("AddTemplate")]
+        [Admin]
+
         public async Task<ResponseBase<bool>> AddTemplate(EmailTemplate template)
         {
             return await _emailService.AddTemplateAsync(template);
         }
 
         [HttpPut("UpdateTemplate/{id}")]
+        [Admin]
+
         public async Task<ResponseBase<bool>> UpdateTemplate(int id, EmailTemplate template)
         {
             if (id != template.Id) 
@@ -46,6 +51,8 @@ namespace DevJobsBackend.Controllers
         }
 
         [HttpDelete("DeleteTemplate/{id}")]
+        [Admin]
+
         public async Task<ResponseBase<bool>> DeleteTemplate(int id)
         {
             return await _emailService.DeleteTemplateAsync(id);

--- a/Controllers/EmailController.cs
+++ b/Controllers/EmailController.cs
@@ -24,7 +24,7 @@ namespace DevJobsBackend.Controllers
         {
             return await _emailService.GetAllTemplatesAsync();
         }
-
+        [Admin]
         [HttpGet("GetTemplateById/{id}")]
         public async Task<ResponseBase<EmailTemplate>> GetTemplateById(int id)
         {

--- a/IoC/Services/ServicesMapping.cs
+++ b/IoC/Services/ServicesMapping.cs
@@ -23,7 +23,8 @@ namespace DevJobsBackend.IoC.Services
             
             services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
 
-            services.AddScoped<IModelBinderProvider, UserModelBinderProvider>();
+            services.AddScoped<IModelBinderProvider, UserModelBinderProvider>(); 
+            services.AddScoped<IModelBinderProvider, AdminModelBinderProvider>(); 
 
             // AutoMapper
             var mapperConfig = new MapperConfiguration(mc =>

--- a/annotations/AdminAnotation.cs
+++ b/annotations/AdminAnotation.cs
@@ -1,29 +1,66 @@
-﻿using DevJobsBackend.Entities;
+﻿using DevJobsBackend.Contracts.Services;
 using DevJobsBackend.Enums;
+using DevJobsBackend.Responses;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
 public class AdminAttribute : Attribute, IAsyncActionFilter
 {
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        // Obtém o CurrentUser do contexto
-        if (context.HttpContext.Items.TryGetValue("CurrentUser", out var currentUserObj) && currentUserObj is User currentUser)
+        var authService = context.HttpContext.RequestServices.GetService<IAuthService>();
+        var authorizationHeader = context.HttpContext.Request.Headers["Authorization"].FirstOrDefault();
+
+        if (string.IsNullOrEmpty(authorizationHeader) || !authorizationHeader.StartsWith("Bearer "))
         {
-            if ( currentUser.TypeUser == UserType.ADMIN)
+            SetUnauthorizedResult(context, "Authorization header is missing or invalid.");
+            return;
+        }
+
+        var token = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+        try
+        {
+            var user = await authService.GetUserByAccessToken(token);
+
+            if (user != null && user.TypeUser == UserType.ADMIN)
             {
                 await next();
             }
             else
             {
-                context.Result = new ForbidResult();
+                SetForbiddenResult(context, "Access denied. You do not have the required permissions.");
             }
         }
-        else
+        catch
         {
-            context.Result = new UnauthorizedResult();
+            SetUnauthorizedResult(context, "Invalid token or user not authenticated.");
         }
+    }
+
+    private void SetUnauthorizedResult(ActionExecutingContext context, string message)
+    {
+        var response = new ResponseBase<object>
+        {
+            Data = null,
+            Message = message,
+            Status = false
+        };
+        context.Result = new JsonResult(response) { StatusCode = 401 }; // Unauthorized
+    }
+
+    private void SetForbiddenResult(ActionExecutingContext context, string message)
+    {
+        var response = new ResponseBase<object>
+        {
+            Data = null,
+            Message = message,
+            Status = false
+        };
+        context.Result = new JsonResult(response) { StatusCode = 403 }; // Forbidden
     }
 }

--- a/annotations/AdminAnotation.cs
+++ b/annotations/AdminAnotation.cs
@@ -1,0 +1,29 @@
+﻿using DevJobsBackend.Entities;
+using DevJobsBackend.Enums;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Threading.Tasks;
+
+public class AdminAttribute : Attribute, IAsyncActionFilter
+{
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        // Obtém o CurrentUser do contexto
+        if (context.HttpContext.Items.TryGetValue("CurrentUser", out var currentUserObj) && currentUserObj is User currentUser)
+        {
+            if ( currentUser.TypeUser == UserType.ADMIN)
+            {
+                await next();
+            }
+            else
+            {
+                context.Result = new ForbidResult();
+            }
+        }
+        else
+        {
+            context.Result = new UnauthorizedResult();
+        }
+    }
+}


### PR DESCRIPTION
### Add admin authorization annotation

This PR adds a new `[Admin]` annotation to verify if a user is an administrator. The annotation checks the JWT token, authenticates the user, and verifies their role. If the user is not an admin, it returns a `403 Forbidden` response.

#### Changes:
- Added `AdminAnnotation.cs` to handle admin verification using an asynchronous action filter.
- Updated `EmailController.cs` to use the `[Admin]` attribute on necessary endpoints.
- Configured `AdminModelBinder` and `AdminModelBinderProvider` to integrate the admin verification logic.

#### Testing:
- Verified that accessing the endpoints with an admin token works correctly.
- Verified that accessing the endpoints with a non-admin token returns a `403 Forbidden` response.
- Verified that accessing the endpoints without a token returns a `401 Unauthorized` response.

Please review the changes and let me know if any adjustments are needed.
