### PR TITLE
fix: docker fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,26 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+# Base image
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 WORKDIR /app
 EXPOSE 5000
 
-# Build
+# Build stage
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY ["DevJobsBackend.csproj", "."]
+COPY ["DevJobsBackend.csproj", "./"]
 RUN dotnet restore "./DevJobsBackend.csproj"
 COPY . .
 WORKDIR "/src/DevJobsBackend"
 RUN dotnet build "../DevJobsBackend.csproj" -c Release -o /app/build
-
-# Publish
-FROM build AS publish
 RUN dotnet publish "../DevJobsBackend.csproj" -c Release -o /app/publish
 
-# Migrations
-FROM publish AS migrations
-WORKDIR /app/publish
+# Final stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+COPY --from=build /src /src
 RUN dotnet tool install --global dotnet-ef
 ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet ef database update
-
-# End
-FROM base AS final
-WORKDIR /app
-COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS=http://+:5000
-ENTRYPOINT ["dotnet", "DevJobsBackend.dll"]
+COPY entrypoint.sh .
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+echo "Waiting for database to be available..."
+until dotnet ef database update --project /src/DevJobsBackend.csproj; do
+  >&2 echo "Database is unavailable - sleeping"
+  sleep 5
+done
+
+echo "Starting application..."
+exec dotnet DevJobsBackend.dll


### PR DESCRIPTION
Our front-end team encountered some issues with the database. To resolve them the same way we did, they would need to install .NET on their computers. To address this, I changed the Dockerfile and added a bash script to our project. Now, it will always run dotnet ef database update because this command was not executing before, even though it was included in the Dockerfile.